### PR TITLE
Add meta field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `livewire-filters` will be documented in this file.
 
-## 0.1 - 202X-XX-XX
+## 0.2 - 2022-xx-xx
 
-- initial release
+- Added the `meta` field to `Filter` class
+
+## 0.1 - 2022-02-28
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ If you would like to set the value of a filter, you can pass the value or an arr
 
 When defining a filter, you should use the `default` method to set the initial value of the filter. This will store the initial value on the object as well to help with determining the status of active filters as well as resetting the filter to its original state. Calling the `default` method without any arguments will return the initial value that you specified when you defined the filter.
 
+### `meta(array $values)`
+
+If you would like to set additional information on the filter to be used in the view file, you can pass an array of values into the `meta` method. Calling the `meta` method without any arguments will return the current array of meta information.
+
 ## Events
 
 ### `livewire-filters-reset`

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -8,7 +8,8 @@ class Filter
         public string $key,
         public ?array $options = [],
         public mixed $value = '',
-        public mixed $initialValue = ''
+        public mixed $initialValue = '',
+        public array $meta = []
     ) {
     }
 

--- a/src/FilterComponent.php
+++ b/src/FilterComponent.php
@@ -10,6 +10,8 @@ abstract class FilterComponent extends Component
 
     public string $key = '';
 
+    public array $meta = [];
+
     public array $options = [];
 
     public mixed $value;
@@ -17,6 +19,7 @@ abstract class FilterComponent extends Component
     public function mount(Filter $filter): void
     {
         $this->key = $filter->key();
+        $this->meta = $filter->meta();
         $this->options = $filter->options();
         $this->value = $filter->value();
 


### PR DESCRIPTION
This PR adds a `meta` field on the `Filter` class to allow passing arbitrary values when defining the filter.

```php
Filter::make('status')
  ->options(['active', 'inactive', 'pending')
  ->default(['active'])
  ->meta(['label' => 'User Status']);
```

```blade
<div>
  <h2>{{ data_get($meta, 'label') }}</h2>
  ...
</div>
```