### PR TITLE
Add support for state preservation via query string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `livewire-filters` will be documented in this file.
 
+## 0.4 - 2023-01-10
+
+- Added state preservation support via query string, controllable through `query_string_enabled` configuration key.
+
 ## 0.3 - 2022-03-05
 
 - Added `getOptionId` method for better handling of setting an option's ID attribute when dealing with associative arrays

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ The included filters are made with [Tailwind CSS](https://tailwindcss.com) and t
 php artisan vendor:publish --tag=livewire-filters-views
 ```
 
+### Publishing config
+
+Publishing the config file is only necessary to enable query string usage.
+```bash
+php artisan vendor:publish --tag=livewire-filters-config
+```
+
 ## Usage
 
 ### Define your filters

--- a/config/livewire-filters.php
+++ b/config/livewire-filters.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'query_string_enabled' => false,
+];

--- a/src/FilterComponent.php
+++ b/src/FilterComponent.php
@@ -15,16 +15,34 @@ abstract class FilterComponent extends Component
 
     public array $options = [];
 
-    public mixed $value;
+    public mixed $value = null;
 
     public function mount(Filter $filter): void
     {
         $this->key = $filter->key();
         $this->meta = $filter->meta();
         $this->options = $filter->options();
-        $this->value = $filter->value();
 
-        $this->initialValue = $this->value;
+        if (config('livewire-filters.query_string_enabled')) {
+            $this->value = request()?->query($filter->key()) ?? $filter->value();
+        } else {
+            $this->value = $filter->value();
+        }
+
+        $this->initialValue = $filter->value();
+    }
+
+    protected function queryString(): array
+    {
+        if (!config('livewire-filters.query_string_enabled')) {
+            return [];
+        }
+
+        return [
+            'value' => [
+                'as' => $this->key,
+            ],
+        ];
     }
 
     public function resetValue(): void

--- a/src/LivewireFiltersServiceProvider.php
+++ b/src/LivewireFiltersServiceProvider.php
@@ -16,6 +16,7 @@ class LivewireFiltersServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('livewire-filters')
+            ->hasConfigFile()
             ->hasViews();
     }
 


### PR DESCRIPTION
When enabled (`livewire-filters.query_string_enabled`), the modified fields will save or restore their state from the URL.

